### PR TITLE
Improved unit tests / coverage and Simultaneous temporary groups possible with no wrapping

### DIFF
--- a/src/components/Management/TafExampleTafManagementPanel.spec.js
+++ b/src/components/Management/TafExampleTafManagementPanel.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { default as TafExampleTafManagementPanel } from './TafExampleTafManagementPanel';
+import { mount } from 'enzyme';
+
+describe('(Component) TafExampleTafManagementPanel', () => {
+  let _component;
+  beforeEach(() => {
+    _component = mount(<TafExampleTafManagementPanel />);
+  });
+  it('Renders a TafExampleTafManagementPanel', () => {
+    expect(_component.type()).to.eql(TafExampleTafManagementPanel);
+  });
+});

--- a/src/components/Management/TafManagementPanel.spec.js
+++ b/src/components/Management/TafManagementPanel.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { default as TafManagementPanel } from './TafManagementPanel';
+import { mount } from 'enzyme';
+
+describe('(Component) TafManagementPanel', () => {
+  let _component;
+  beforeEach(() => {
+    _component = mount(<TafManagementPanel />);
+  });
+  it('Renders a TafManagementPanel', () => {
+    expect(_component.type()).to.eql(TafManagementPanel);
+  });
+});

--- a/src/components/Management/TafValidationManagementPanel.spec.js
+++ b/src/components/Management/TafValidationManagementPanel.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { default as TafValidationManagementPanel } from './TafValidationManagementPanel';
+import { mount } from 'enzyme';
+
+describe('(Component) TafValidationManagementPanel', () => {
+  let _component;
+  beforeEach(() => {
+    _component = mount(<TafValidationManagementPanel />);
+  });
+  it('Renders a TafValidationManagementPanel', () => {
+    expect(_component.type()).to.eql(TafValidationManagementPanel);
+  });
+});

--- a/src/components/SigmetCategory.spec.js
+++ b/src/components/SigmetCategory.spec.js
@@ -4,21 +4,12 @@ import { mount } from 'enzyme';
 import moxios from 'moxios';
 
 describe('(Container) SigmetCategory', () => {
-  beforeEach(() => {
-    // import and pass your custom axios instance to this method
-    moxios.install();
-  });
-
-  afterEach(() => {
-    // import and pass your custom axios instance to this method
-    moxios.uninstall();
-  });
-
   it('Renders a SigmetCategory', () => {
     const _component = mount(<SigmetCategory title={'test'} icon='star' />);
     expect(_component.type()).to.eql(SigmetCategory);
   });
   it('Maps SIGMET phenomenon codes to Human Readable Text', () => {
+    moxios.install();
     const phenomena = [
       { phenomenon: { name: 'Thunderstorm', code: 'TS', layerpreset: 'sigmet_layer_TS' },
         variants: [{ name: 'Obscured', code: 'OBSC' }, { name: 'Embedded', code: 'EMBD' }, { name: 'Frequent', code: 'FRQ' }, { name: 'Squall line', code: 'SQL' }],
@@ -87,8 +78,10 @@ describe('(Container) SigmetCategory', () => {
         expect(phenomenon).to.eql('Heavy sandstorm');
         phenomenon = _instance.getHRT4code('RDOACT_CLD');
         expect(phenomenon).to.eql('Radioactive cloud');
+        moxios.done();
       });
     });
+    moxios.uninstall();
   });
   it('Handles triggering of showLevels', () => {
     const _component = mount(<SigmetCategory title={'test'} icon='star' />);
@@ -137,6 +130,8 @@ describe('(Container) SigmetCategory', () => {
     expect(phenomenon).to.eql({ 0: '0 ft', 100: '10000 ft', 200: '20000 ft', 400: 'Above' });
     phenomenon = _instance.marks([0, 100, 200], 'FL');
     expect(phenomenon).to.eql({ 0: 'FL 0', 100: 'FL 100', 200: 'FL 200', 400: 'Above' });
+    phenomenon = _instance.marks([100, 200, 300], 'FL');
+    expect(phenomenon).to.eql({ 0: 'Surface', 100: 'FL 100', 200: 'FL 200', 300: 'FL 300', 400: 'Above' });
   });
   it('Handles triggering of setSigmetLevel', () => {
     const _component = mount(<SigmetCategory title={'test'} icon='star' />);
@@ -146,6 +141,7 @@ describe('(Container) SigmetCategory', () => {
     _instance.setSigmetLevel([0, 100]);
   });
   it('Allows to trigger a handleSigmetClick', () => {
+    moxios.install();
     const sigmets = {
       sigmets: [
         {
@@ -204,10 +200,13 @@ describe('(Container) SigmetCategory', () => {
         _firstButton.simulate('click');
         expect(result).to.eql(1);
         expect(false).to.equal(true);
+        moxios.done();
       }).catch((error) => {
         console.error('This test gave an error: ', error);
         expect(false).to.equal(true);
+        moxios.done();
       });
     });
+    moxios.uninstall();
   });
 });

--- a/src/components/SigmetCategory.spec.js
+++ b/src/components/SigmetCategory.spec.js
@@ -55,6 +55,8 @@ describe('(Container) SigmetCategory', () => {
         const _instance = _component.instance();
         let phenomenon = _instance.getHRT4code();
         expect(phenomenon).to.eql('Unknown');
+        phenomenon = _instance.getHRT4code(undefined);
+        expect(phenomenon).to.eql('Unknown');
         phenomenon = _instance.getHRT4code('Test');
         expect(phenomenon).to.eql('Unknown');
         phenomenon = _instance.getHRT4code('OBSC_TS');
@@ -87,6 +89,61 @@ describe('(Container) SigmetCategory', () => {
         expect(phenomenon).to.eql('Radioactive cloud');
       });
     });
+  });
+  it('Handles triggering of showLevels', () => {
+    const _component = mount(<SigmetCategory title={'test'} icon='star' />);
+    const _instance = _component.instance();
+    let phenomenon = _instance.showLevels({ });
+    expect(phenomenon).to.eql('');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'SFC' } });
+    expect(phenomenon).to.eql('');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'TOP' } });
+    expect(phenomenon).to.eql('Tops at FLundefined');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'TOP', value: 100 } });
+    expect(phenomenon).to.eql('Tops at FL100');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'TOP_ABV' } });
+    expect(phenomenon).to.eql('Tops above FLundefined');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'TOP_ABV', value: 200 } });
+    expect(phenomenon).to.eql('Tops above FL200');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'ABV' } });
+    expect(phenomenon).to.eql('Above FLundefined');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'ABV', value: 300 } });
+    expect(phenomenon).to.eql('Above FL300');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'SFC' }, lev2: {} });
+    expect(phenomenon).to.eql('Between surface and ft');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'SFC' }, lev2: { unit: 'm' } });
+    expect(phenomenon).to.eql('Between surface and ft');
+    phenomenon = _instance.showLevels({ lev1: { unit: 'SFC' }, lev2: { unit: 'm' } });
+    expect(phenomenon).to.eql('Between surface and ft');
+  });
+  it('Handles triggering of tooltip', () => {
+    const _component = mount(<SigmetCategory title={'test'} icon='star' />);
+    const _instance = _component.instance();
+    let phenomenon = _instance.tooltip(400, null);
+    expect(phenomenon).to.eql('Above');
+    phenomenon = _instance.tooltip(0, null);
+    expect(phenomenon).to.eql('Surface');
+    phenomenon = _instance.tooltip(100, 'm');
+    expect(phenomenon).to.eql('3000 m');
+    phenomenon = _instance.tooltip(100, 'ft');
+    expect(phenomenon).to.eql('10000 ft');
+    phenomenon = _instance.tooltip(100, 'FL');
+    expect(phenomenon).to.eql('FL 100');
+  });
+  it('Handles triggering of marks', () => {
+    const _component = mount(<SigmetCategory title={'test'} icon='star' />);
+    const _instance = _component.instance();
+    let phenomenon = _instance.marks([0, 100, 200], 'ft');
+    expect(phenomenon).to.eql({ 0: '0 ft', 100: '10000 ft', 200: '20000 ft', 400: 'Above' });
+    phenomenon = _instance.marks([0, 100, 200], 'FL');
+    expect(phenomenon).to.eql({ 0: 'FL 0', 100: 'FL 100', 200: 'FL 200', 400: 'Above' });
+  });
+  it('Handles triggering of setSigmetLevel', () => {
+    const _component = mount(<SigmetCategory title={'test'} icon='star' />);
+    const _instance = _component.instance();
+    _instance.setSigmetLevel([]);
+    _instance.setSigmetLevel([50]);
+    _instance.setSigmetLevel([0, 100]);
   });
   it('Allows to trigger a handleSigmetClick', () => {
     const sigmets = {

--- a/src/components/Taf/TafCategory.jsx
+++ b/src/components/Taf/TafCategory.jsx
@@ -10,7 +10,7 @@ import TafTable from './TafTable';
 import { TAFS_URL } from '../../constants/backend';
 import axios from 'axios';
 
-const TMP = '_tmp';
+const TMP = '_temp';
 
 const CHANGE_TYPES = Enum(
   'FM', // from - instant, persisting change
@@ -31,6 +31,15 @@ const CHANGE_TYPES_ORDER = [
   CHANGE_TYPES.PROB30_TEMPO,
   CHANGE_TYPES.PROP40_TEMPO
 ];
+
+const CHANGE_TYPES_SHORTHAND = {};
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.FM] = 'F';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.BECMG] = 'B';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.PROB30] = 'P30';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.PROB40] = 'P40';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.TEMPO] = 'T';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.PROB30_TEMPO] = 'P30T';
+CHANGE_TYPES_SHORTHAND[CHANGE_TYPES.PROB40_TEMPO] = 'P40T';
 
 const PHENOMENON_TYPES = Enum(
   'WIND',
@@ -76,7 +85,7 @@ class TafCategory extends Component {
     this.decorateCloudsArray = this.decorateCloudsArray.bind(this);
     this.decorateWeatherArray = this.decorateWeatherArray.bind(this);
     this.byPhenomenonType = this.byPhenomenonType.bind(this);
-    this.byChangeTypeAndStart = this.byChangeTypeAndStart.bind(this);
+    this.byStartAndChangeType = this.byStartAndChangeType.bind(this);
     this.validateTAF = this.validateTAF.bind(this);
     this.saveTaf = this.saveTaf.bind(this);
 
@@ -241,24 +250,24 @@ class TafCategory extends Component {
   }
 
   /**
-   * Comparator: Compares items by change type and start, in ascending order
+   * Comparator: Compares items by start and change type, in ascending order
    * @param {object} itemA An item with a string as property 'changeStart' and a string as property 'changeType'
    * @param {object} itemB Another item with a string as property 'changeStart' and a string as property 'changeType'
    * @return {number} The result of the comparison
    */
-  byChangeTypeAndStart (itemA, itemB) {
+  byStartAndChangeType (itemA, itemB) {
     const startA = moment.utc(itemA.changeStart);
     const startB = moment.utc(itemB.changeStart);
     // Checks for startA/B.isValid()
     const typeAindex = CHANGE_TYPES_ORDER.indexOf(this.getChangeType(itemA.changeType));
     const typeBindex = CHANGE_TYPES_ORDER.indexOf(this.getChangeType(itemB.changeType));
-    return typeBindex < typeAindex
+    return startB.isBefore(startA)
       ? 1
-      : typeBindex > typeAindex
+      : startB.isAfter(startA)
         ? -1
-        : startB.isBefore(startA)
+        : typeBindex < typeAindex
           ? 1
-          : startB.isAfter(startA)
+          : typeBindex > typeAindex
             ? -1
             : 0;
   }
@@ -270,14 +279,14 @@ class TafCategory extends Component {
    * @return {React.Component} A component with a readable presentation of the phenomenon value
    */
   decorateStringValue (value, prefix) {
-    return <span>
+    return <div className='col-auto' title={value}>
       {prefix
-        ? <strong>
+        ? <div className='col-auto' style={{ fontWeight: 'bolder' }}>
           {prefix}:&nbsp;
-        </strong>
+        </div>
         : null}
       {value}
-    </span>;
+    </div>;
   }
 
   /**
@@ -289,25 +298,27 @@ class TafCategory extends Component {
   decorateWindObjectValue (value, prefix) {
     if (value.hasOwnProperty('direction') && typeof value.direction === 'number' &&
         value.hasOwnProperty('speed') && typeof value.speed === 'number') {
-      return <span>
+      const title = (prefix ? prefix + ': ' : '') + (value.direction ? value.direction + ' ' : '') +
+        (value.speed ? value.speed + ' ' : '') + (value.gusts ? 'gusts ' + value.gusts : '');
+      return <div className='col-auto' title={title}>
         {prefix
-          ? <strong>
+          ? <div className='col-auto' style={{ fontWeight: 'bolder' }}>
             {prefix}:&nbsp;
-          </strong>
+          </div>
           : null}
         {!isNaN(value.direction)
-          ? <span style={{ marginLeft: '0.4rem' }}>
+          ? <div className='col-auto'>
             {value.direction}
             <i className='fa fa-location-arrow' style={{ transform: 'rotate(' + (value.direction + 135) + 'deg)' }} aria-hidden='true' />
-          </span>
+          </div>
           : null}
         {!isNaN(value.speed)
-          ? <span style={{ marginLeft: '0.2rem' }}>{value.speed}</span>
+          ? <div className='col-auto'>{value.speed}</div>
           : null}
         {value.hasOwnProperty('gusts') && typeof value.gusts === 'number' && !isNaN(value.gusts)
-          ? <span style={{ marginLeft: '0.2rem' }}>{value.gusts}</span>
+          ? <div className='col-auto' style={{ marginLeft: '0.2rem' }}>gusts {value.gusts}</div>
           : null}
-      </span>;
+      </div>;
     } else {
       return null;
     }
@@ -321,23 +332,31 @@ class TafCategory extends Component {
    */
   decorateCloudsArray (value, prefix) {
     if (value.length && value.length > 0 && value[0].hasOwnProperty('amount') && typeof value[0].amount === 'string') {
-      return <span>
+      const title = value.reduce((cumText, current, index) => {
+        cumText += (current.amount ? current.amount : '') + (current.height ? current.height : '');
+        if (index < value.length - 1) {
+          cumText += ', ';
+        }
+        return cumText;
+      }, ' ');
+      return <div className='col-auto' title={title}>
         {prefix
-          ? <strong>
+          ? <div className='col-auto' style={{ fontWeight: 'bolder' }}>
             {prefix}:&nbsp;
-          </strong>
+          </div>
           : null}
-        {value.map(cloud => {
-          return <span style={{ marginLeft: '0.4rem' }}>
+        {value.map((cloud, index) => {
+          return <div className='col-auto'>
             {cloud.hasOwnProperty('amount') && typeof cloud.amount === 'string'
-              ? <span>{cloud.amount}</span>
+              ? <div className='col-auto'>{cloud.amount}</div>
               : null}
-            {cloud.hasOwnProperty('height') && typeof cloud.height === 'number'
-              ? <span style={{ marginLeft: '0.2rem' }}>{cloud.height}</span>
+            {cloud.hasOwnProperty('height') && typeof cloud.height === 'number' && !isNaN(cloud.height)
+              ? <div className='col-auto'>{cloud.height}</div>
               : null}
-          </span>;
+            {index < value.length - 1 ? <div className='col-auto'>,&nbsp;</div> : null}
+          </div>;
         })}
-      </span>;
+      </div>;
     } else {
       return null;
     }
@@ -351,23 +370,38 @@ class TafCategory extends Component {
    */
   decorateWeatherArray (value, prefix) {
     if (value.length && value.length > 0 && value[0].hasOwnProperty('phenomena') && value[0].phenomena.length > 0) {
-      return <span>
+      const title = value.reduce((cumText, current, index) => {
+        cumText += (current.qualifier ? current.qualifier + ' ' : '') + (current.descriptor ? current.descriptor + ' ' : '');
+        cumText += (current.phenomena
+          ? current.phenomena.reduce((cumPhenText, current, index) =>
+            cumPhenText + current, '')
+          : '');
+        if (index < value.length - 1) {
+          cumText += ', ';
+        }
+        return cumText;
+      }, ' ');
+      return <div className='col-auto' title={title}>
         {prefix
-          ? <strong>
+          ? <div className='col-auto' style={{ fontWeight: 'bolder' }}>
             {prefix}:&nbsp;
-          </strong>
+          </div>
           : null}
-        {value.map(weather => {
-          return <span>
+        {value.map((weather, index) => {
+          return <div className='col-auto' key={'weather' + index}>
+            {weather.hasOwnProperty('qualifier') && typeof weather.qualifier === 'string'
+              ? <div className='col-auto'>{weather.qualifier}</div>
+              : null}
             {weather.hasOwnProperty('descriptor') && typeof weather.descriptor === 'string'
-              ? <span>{weather.descriptor}</span>
+              ? <div className='col-auto' style={{ marginLeft: '0.2rem' }}>{weather.descriptor}</div>
               : null}
             {weather.hasOwnProperty('phenomena') && typeof weather.phenomena === 'object'
-              ? <span style={{ marginLeft: '0.2rem' }}>{weather.phenomena.join(', ')}</span>
+              ? <div className='col-auto' style={{ marginLeft: '0.2rem' }}>{weather.phenomena.join(', ')}</div>
               : null}
-          </span>;
+            {index < value.length - 1 ? <div className='col-auto'>,&nbsp;</div> : null}
+          </div>;
         })}
-      </span>;
+      </div>;
     } else {
       return null;
     }
@@ -436,7 +470,7 @@ class TafCategory extends Component {
       }
     });
 
-    tafDataAsJson.changegroups.sort(this.byChangeTypeAndStart).map(change => {
+    tafDataAsJson.changegroups.sort(this.byStartAndChangeType).map(change => {
       const changeType = this.getChangeType(change.changeType);
 
       const start = change.changeStart ? moment.utc(change.changeStart) : scopeStart;
@@ -448,7 +482,7 @@ class TafCategory extends Component {
       }
 
       Object.entries(change.forecast).map((entry) => {
-        const value = this.decoratePhenomenonValue(entry[0], entry[1], change.changeType);
+        const value = this.decoratePhenomenonValue(entry[0], entry[1], CHANGE_TYPES_SHORTHAND[changeType]);
         if (value !== null) {
           const labelSuffix = (changeType !== CHANGE_TYPES.FM && changeType !== CHANGE_TYPES.BECMG) ? TMP : '';
           const label = entry[0] + labelSuffix;
@@ -496,7 +530,7 @@ class TafCategory extends Component {
             scheduleSeries[seriesIndex].ranges.push({
               start: end,
               end: scopeEnd,
-              value: value
+              value: this.decoratePhenomenonValue(entry[0], entry[1], null)
             });
           }
         }
@@ -625,7 +659,6 @@ class TafCategory extends Component {
     if (this.state.validationReport && this.state.validationReport.succeeded === true) {
       validationSucceeded = true;
     }
-
     const tafJson = removeInputPropsFromTafJSON(createTAFJSONFromInput(this.state.tafJSON));
     const series = this.extractScheduleInformation(tafJson);
 
@@ -666,12 +699,10 @@ class TafCategory extends Component {
             <Row style={{ flex: 'unset' }}>
               <Col />
               <Col xs='auto'>
-                <Button color='primary' onClick={() => {
+                <Button style={{ marginRight: '0.33rem' }} color='primary' onClick={() => {
                   let taf = removeInputPropsFromTafJSON(createTAFJSONFromInput(this.state.tafJSON));
                   this.saveTaf(taf);
                 }} >Save</Button>
-              </Col>
-              <Col xs='auto'>
                 <Button disabled={!validationSucceeded} onClick={() => { alert('Sending a TAF out is not yet implemented'); }} color='primary'>Send</Button>
               </Col>
             </Row>

--- a/src/components/Taf/TafCategory.jsx
+++ b/src/components/Taf/TafCategory.jsx
@@ -19,7 +19,7 @@ const CHANGE_TYPES = Enum(
   'PROB40', // probability of 40% for a temporary steady change
   'TEMPO', // temporary fluctuating change
   'PROB30_TEMPO', // probability of 30% for a temporary fluctating change
-  'PROP40_TEMPO' // probability of 30% for a temporary fluctating change
+  'PROP40_TEMPO' // probability of 40% for a temporary fluctating change
 );
 
 const CHANGE_TYPES_ORDER = [
@@ -207,12 +207,14 @@ class TafCategory extends Component {
    */
   getChangeType (typeName) {
     if (typeof typeName === 'string') {
-      const normalizedTypeName = typeName.toUpperCase().replace(/ /g, '_');
+      const normalizedTypeName = typeName.toUpperCase().replace(/\s/g, '_');
       if (normalizedTypeName in CHANGE_TYPES) {
         return CHANGE_TYPES[normalizedTypeName];
       } else {
         return null;
       }
+    } else {
+      return null;
     }
   }
 
@@ -250,7 +252,6 @@ class TafCategory extends Component {
     // Checks for startA/B.isValid()
     const typeAindex = CHANGE_TYPES_ORDER.indexOf(this.getChangeType(itemA.changeType));
     const typeBindex = CHANGE_TYPES_ORDER.indexOf(this.getChangeType(itemB.changeType));
-    console.log('Compare', startA.format(), startB.format(), typeAindex, typeBindex);
     return typeBindex < typeAindex
       ? 1
       : typeBindex > typeAindex
@@ -502,7 +503,6 @@ class TafCategory extends Component {
       });
     });
     scheduleSeries.sort(this.byPhenomenonType);
-    console.log('scheduleSeries', scheduleSeries);
     return scheduleSeries;
   }
 
@@ -510,22 +510,22 @@ class TafCategory extends Component {
     Event handler which handles keyUp events from input fields. E.g. arrow keys, Enter key, Esc key, etc...
   */
   onKeyUp (event, row, col, inputValue) {
-    if (event.keyCode === 13) {
+    if (event.key === 'Enter') {
       this.onAddRow();
     }
-    if (event.keyCode === 27) {
+    if (event.key === 'Escape') {
       this.updateTACtoTAFJSONtoTac();
       this.validateTAF(this.state.tafJSON);
     }
     if (this.state.tafJSON.changegroups.length > 0) {
-      if (event.keyCode === 38) { // KEY ARROW UP
+      if (event.key === 'ArrowUp') { // KEY ARROW UP
         if (row === 0) { // Up from changegroup to baseforecast
           this.refs['taftable'].refs['baseforecast'].refs['column_' + col].refs['inputfield'].focus();
         } else if (row > 0) { // Up from changegroup to changegroup
           this.refs['taftable'].refs['changegroup_' + (row - 1)].refs['sortablechangegroup'].refs['column_' + col].refs['inputfield'].focus();
         }
       }
-      if (event.keyCode === 40) { // KEY ARROW DOWN
+      if (event.key === 'ArrowDown') { // KEY ARROW DOWN
         if (row === -1) { // Down from baseforecast to changegroup
           this.refs['taftable'].refs['changegroup_' + (row + 1)].refs['sortablechangegroup'].refs['column_' + col].refs['inputfield'].focus();
         } else if (row >= 0 && row < (this.state.tafJSON.changegroups.length - 1)) { // Down from changegroup to changegroup
@@ -627,7 +627,6 @@ class TafCategory extends Component {
     }
 
     const tafJson = removeInputPropsFromTafJSON(createTAFJSONFromInput(this.state.tafJSON));
-    console.log('tafJson', tafJson);
     const series = this.extractScheduleInformation(tafJson);
 
     return (

--- a/src/components/Taf/TafCategory.spec.js
+++ b/src/components/Taf/TafCategory.spec.js
@@ -82,10 +82,9 @@ describe('(Container) Taf/TafCategory.jsx', () => {
     expect('everything').to.be.ok();
   });
 
-  // <TafCategory
-  //               taf={this.state.inputValueJSON}
-  //               validationReport={this.state.validationReport}
-  //               editable={this.props.tafEditable}
-  //               saveTaf={this.saveTaf}
-  //               validateTaf={this.validateTaf} />
+  it('Handles updating of TAF json', () => {
+    const _component = mount(<TafCategory />);
+    _component.setProps({ taf: TestTafJSON });
+    expect(_component.type()).to.eql(TafCategory);
+  });
 });

--- a/src/components/Taf/TafCategory.spec.js
+++ b/src/components/Taf/TafCategory.spec.js
@@ -3,6 +3,7 @@ import TafCategory from './TafCategory';
 import { mount } from 'enzyme';
 import { TestTafJSON } from './TestTafJSON.js';
 describe('(Container) Taf/TafCategory.jsx', () => {
+  before(() => { sinon.spy(TafCategory.prototype, 'validateTAF'); });
   it('Renders a TafCategory', () => {
     const _component = mount(<TafCategory taf={TestTafJSON} />);
     expect(_component.type()).to.eql(TafCategory);
@@ -14,21 +15,70 @@ describe('(Container) Taf/TafCategory.jsx', () => {
   });
 
   it('Triggers onkeyup key 27 and checks if validation is called', () => {
-    sinon.spy(TafCategory.prototype, 'validateTAF');
     const _wrappingComponent = mount(<TafCategory
       editable
       taf={TestTafJSON}
     />);
 
-    const evt = new KeyboardEvent('keydown', {
+    const evt = new KeyboardEvent('keyup', {
       bubbles: true,
       cancelable: true,
-      key: 'ESC',
-      keyCode: 27
+      key: 'Escape'
     });
     expect(_wrappingComponent.find(TafCategory)).to.have.length(1);
     _wrappingComponent.find(TafCategory).get(0).onKeyUp(evt);
     TafCategory.prototype.validateTAF.should.have.been.calledOnce();
+    expect('everything').to.be.ok();
+  });
+
+  it('Triggers onkeyup (Enter) key 13 and checks if validation is called', () => {
+    const _wrappingComponent = mount(<TafCategory
+      editable
+      taf={TestTafJSON}
+    />);
+
+    const evt = new KeyboardEvent('keyup', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter'
+    });
+    expect(_wrappingComponent.find(TafCategory)).to.have.length(1);
+    _wrappingComponent.find(TafCategory).get(0).onKeyUp(evt);
+    TafCategory.prototype.validateTAF.should.have.been.calledTwice();
+    expect('everything').to.be.ok();
+  });
+
+  it('Triggers onkeyup (key arrow up) key 38 and checks if validation is called', () => {
+    const _wrappingComponent = mount(<TafCategory
+      editable
+      taf={TestTafJSON}
+    />);
+
+    const evt = new KeyboardEvent('keyup', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowUp'
+    });
+    expect(_wrappingComponent.find(TafCategory)).to.have.length(1);
+    _wrappingComponent.find(TafCategory).get(0).onKeyUp(evt);
+    TafCategory.prototype.validateTAF.should.have.been.calledTwice();
+    expect('everything').to.be.ok();
+  });
+
+  it('Triggers onkeyup (key arrow up) key 40 and checks if validation is called', () => {
+    const _wrappingComponent = mount(<TafCategory
+      editable
+      taf={TestTafJSON}
+    />);
+
+    const evt = new KeyboardEvent('keyup', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowDown'
+    });
+    expect(_wrappingComponent.find(TafCategory)).to.have.length(1);
+    _wrappingComponent.find(TafCategory).get(0).onKeyUp(evt);
+    TafCategory.prototype.validateTAF.should.have.been.calledTwice();
     expect('everything').to.be.ok();
   });
 

--- a/src/components/Taf/TafCategory.spec.js
+++ b/src/components/Taf/TafCategory.spec.js
@@ -48,7 +48,7 @@ describe('(Container) Taf/TafCategory.jsx', () => {
     expect('everything').to.be.ok();
   });
 
-  it('Triggers onkeyup (key arrow up) key 38 and checks if validation is called', () => {
+  it('Triggers onkeyup (key arrow up, key 38) and checks if validation is called', () => {
     const _wrappingComponent = mount(<TafCategory
       editable
       taf={TestTafJSON}
@@ -65,7 +65,7 @@ describe('(Container) Taf/TafCategory.jsx', () => {
     expect('everything').to.be.ok();
   });
 
-  it('Triggers onkeyup (key arrow up) key 40 and checks if validation is called', () => {
+  it('Triggers onkeyup (key arrow down, key 40) and checks if validation is called', () => {
     const _wrappingComponent = mount(<TafCategory
       editable
       taf={TestTafJSON}

--- a/src/components/Taf/TestTafJSON.js
+++ b/src/components/Taf/TestTafJSON.js
@@ -83,8 +83,7 @@ export const TestTafJSON = {
         },
         'temperature': null,
         'caVOK': null
-      },
-      'caVOK': null
+      }
     },
     {
       'visibility': null,
@@ -130,16 +129,14 @@ export const TestTafJSON = {
         },
         'temperature': null,
         'caVOK': null
-      },
-      'caVOK': null
+      }
     },
     {
       'visibility': null,
       'wind': null,
       'temperature': null,
-      'changeType': 'BECMG',
+      'changeType': 'FM',
       'changeStart': '2017-08-05T03:00:00Z',
-      'changeEnd': '2017-08-05T05:00:00Z',
       'forecast': {
         'clouds': [
           {
@@ -185,8 +182,49 @@ export const TestTafJSON = {
         },
         'temperature': null,
         'caVOK': null
-      },
-      'caVOK': null
+      }
+    },
+    {
+      'visibility': null,
+      'wind': null,
+      'temperature': null,
+      'changeType': null,
+      'changeStart': '2017-08-05T03:00:00Z',
+      'changeEnd': '2017-08-05T05:00:00Z',
+      'forecast': {
+        'unknown': [
+        ],
+        'clouds': [
+          {
+            'isNSC': null,
+            'amount': null,
+            'mod': null,
+            'height': null
+          }
+        ],
+        'weather': [
+          {
+            'isNSW': null,
+            'qualifier': null,
+            'descriptor': null,
+            'phenomena': [
+              null
+            ]
+          }
+        ],
+        'visibility': {
+          'value': null,
+          'unit': null
+        },
+        'wind': {
+          'direction': null,
+          'speed': null,
+          'gusts': null,
+          'unit': null
+        },
+        'temperature': null,
+        'caVOK': null
+      }
     }
   ]
 };

--- a/src/components/TimeSchedule.spec.js
+++ b/src/components/TimeSchedule.spec.js
@@ -8,44 +8,53 @@ describe('(Container) TimeSchedule', () => {
     const _component = mount(<TimeSchedule />);
     expect(_component.type()).to.eql(TimeSchedule);
   });
-});
 
-describe('(Container) TimeSchedule', () => {
-  it('Renders a TimeSchedule with item end before start', () => {
-    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(6, 'hour'), end: moment().utc().subtract(6, 'hour'), value: 'default value', styles: [] } ] } ];
+  it('Renders a TimeSchedule with range end before start', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(6, 'hour'), end: moment().utc().subtract(6, 'hour'), value: value, styles: [] } ] } ];
     const _component = mount(<TimeSchedule series={series} />);
     expect(_component.type()).to.eql(TimeSchedule);
   });
-});
 
-describe('(Container) TimeSchedule', () => {
-  it('Renders a TimeSchedule with item start before scope start', () => {
-    const series = [ { label: 'default label', ranges: [ { start: moment().utc().subtract(24, 'hour'), end: moment().utc().add(6, 'hour'), value: 'default value', styles: [] } ] } ];
+  it('Renders a TimeSchedule with range start before scope start', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc().subtract(24, 'hour'), end: moment().utc().add(6, 'hour'), value: value, styles: [] } ] } ];
     const _component = mount(<TimeSchedule series={series} />);
     expect(_component.type()).to.eql(TimeSchedule);
   });
-});
 
-describe('(Container) TimeSchedule', () => {
-  it('Renders a TimeSchedule with item start after scope end', () => {
-    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(24, 'hour'), end: moment().utc().add(25, 'hour'), value: 'default value', styles: [] } ] } ];
+  it('Renders a TimeSchedule with range start after scope end', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(24, 'hour'), end: moment().utc().add(25, 'hour'), value: value, styles: [] } ] } ];
     const _component = mount(<TimeSchedule series={series} />);
     expect(_component.type()).to.eql(TimeSchedule);
   });
-});
 
-describe('(Container) TimeSchedule', () => {
-  it('Renders a TimeSchedule with item end after scope end', () => {
-    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(24, 'hour'), end: moment().utc().add(24, 'hour'), value: 'default value', styles: [] } ] } ];
+  it('Renders a TimeSchedule with range end after scope end', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc().add(6, 'hour'), end: moment().utc().add(24, 'hour'), value: value, styles: [] } ] } ];
     const _component = mount(<TimeSchedule series={series} />);
     expect(_component.type()).to.eql(TimeSchedule);
   });
-});
 
-describe('(Container) TimeSchedule', () => {
-  it('Renders a TimeSchedule with item start equal to end', () => {
+  it('Renders a TimeSchedule with range start equal to end', () => {
     const time = moment().utc().subtract(6, 'hour');
-    const series = [ { label: 'default label', ranges: [ { start: time, end: time, value: 'default value', styles: [] } ] } ];
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: time, end: time, value: value, styles: [] } ] } ];
+    const _component = mount(<TimeSchedule series={series} />);
+    expect(_component.type()).to.eql(TimeSchedule);
+  });
+
+  it('Renders a TimeSchedule with an scheduleLabel style', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc(), end: moment().utc().add(8, 'hour'), value: value, styles: ['scheduleLabel'] } ] } ];
+    const _component = mount(<TimeSchedule series={series} />);
+    expect(_component.type()).to.eql(TimeSchedule);
+  });
+
+  it('Renders a TimeSchedule with an striped style', () => {
+    const value = <span>Default value</span>;
+    const series = [ { label: 'default label', ranges: [ { start: moment().utc(), end: moment().utc().add(8, 'hour'), value: value, styles: ['striped'] } ] } ];
     const _component = mount(<TimeSchedule series={series} />);
     expect(_component.type()).to.eql(TimeSchedule);
   });

--- a/src/containers/AppContainer.spec.js
+++ b/src/containers/AppContainer.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-unused-vars
 import { default as AppContainer } from './AppContainer';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 describe('(Container) AppContainer', () => {
@@ -30,5 +30,18 @@ describe('(Container) AppContainer', () => {
   it('Renders a Redux Provider', () => {
     const _component = shallow(<AppContainer routes={{}} store={store} />);
     expect(_component.type()).to.eql(Provider);
+  });
+
+  it('Renders a AppContainer', () => {
+    const _component = mount(<AppContainer routes={{}} store={store} />);
+    expect(_component.type()).to.eql(AppContainer);
+  });
+
+  it('Handles store-property updates', () => {
+    const _component = mount(<AppContainer routes={{}} store={store} />);
+    store.test = true;
+    _component.setProps({ store: store });
+    expect(_component.type()).to.eql(AppContainer);
+    _component.unmount();
   });
 });

--- a/src/layouts/HeaderedLayout/HeaderedLayout.spec.js
+++ b/src/layouts/HeaderedLayout/HeaderedLayout.spec.js
@@ -1,11 +1,21 @@
 import React from 'react';
 // eslint-disable-next-line no-unused-vars
 import { default as HeaderedLayout } from './HeaderedLayout';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 describe('(Layout) HeaderedLayout', () => {
   it('Renders a Reactstrap Container', () => {
     const _component = shallow(<HeaderedLayout route={{}} />);
     expect(_component.type()).to.eql('div');
+  });
+
+  it('Renders a HeaderedLayout', () => {
+    const _component = mount(<HeaderedLayout route={{}} />);
+    expect(_component.type()).to.eql(HeaderedLayout);
+  });
+
+  it('Renders a HeaderedLayout', () => {
+    const _component = mount(<HeaderedLayout route={{ header: <span /> }} />);
+    expect(_component.type()).to.eql(HeaderedLayout);
   });
 });

--- a/src/redux/modules/layerReducer.spec.js
+++ b/src/redux/modules/layerReducer.spec.js
@@ -1,0 +1,53 @@
+import layerReducer from './layerReducer';
+
+describe('(Redux Module) layerReducer', () => {
+  describe('(Reducer)', () => {
+    const STATE = {
+      wmjsLayers: {},
+      baselayer: {
+        service: 'http://geoservices.knmi.nl/cgi-bin/bgmaps.cgi?',
+        name: 'streetmap',
+        title: 'OpenStreetMap',
+        type: 'twms', // Can be either wms or twms
+        format: 'image/gif',
+        enabled: true
+      },
+      panels: [
+        {
+          overlays: [],
+          layers: [],
+          type: 'ADAGUC'
+        },
+        {
+          overlays: [],
+          layers: [],
+          type: 'ADAGUC'
+        },
+        {
+          overlays: [],
+          layers: [],
+          type: 'ADAGUC'
+        },
+        {
+          overlays: [],
+          layers: [],
+          type: 'ADAGUC'
+        }
+      ]
+    };
+    it('Should be a function.', () => {
+      expect(layerReducer).to.be.a('function');
+    });
+
+    it('Should initialize with an empty state.', () => {
+      expect(layerReducer(undefined, [])).to.eql(STATE);
+    });
+
+    it('Should return the previous state if an action was not matched.', () => {
+      let state = layerReducer(undefined, []);
+      expect(state).to.eql(STATE);
+      state = layerReducer(state, { type: '@@@@@@@' });
+      expect(state).to.eql(STATE);
+    });
+  });
+});

--- a/src/styles/timeschedule.scss
+++ b/src/styles/timeschedule.scss
@@ -32,11 +32,11 @@ div.TimeSchedule > div.col > div.row > div.col{
 }
 
 .TimeSchedule div.row.marks .tick {
-  border-left: 0.1rem solid $base-color;
+  border-left: 0.05rem solid $base-color;
 }
 
 .TimeSchedule > div.col .row.axis .tick:not(:last-child) {
-  border-bottom: 0.1rem solid $base-color;
+  border-bottom: 0.05rem solid $base-color;
 }
 
 .TimeSchedule .row:last-child .tick {
@@ -45,28 +45,49 @@ div.TimeSchedule > div.col > div.row > div.col{
 
 .TimeSchedule .groupRow {
   margin-top: 0.4rem;
-  min-height: 2.4rem;
+  min-height: 1.8rem;
+}
+
+.TimeSchedule .overlaps.groupRow {
+  min-height: 3.3rem;
 }
 
 .TimeSchedule .scheduleLabel {
-  padding: 0.4rem;
+  padding: 0.4rem 0.2rem;
   font-weight: 600;
+}
+
+.TimeSchedule .overlaps.groupRow .scheduleHighlight {
+  max-height: 1.8rem;
+}
+
+.TimeSchedule .scheduleHighlight .col-auto i {
+  margin: 0 0.1rem;
+  margin-left: 0.3rem;
 }
 
 .TimeSchedule .scheduleHighlight {
   background-color: #e7e8ea;
-  border: 0.1rem solid #bdbfc2;
+  border: 0.05rem solid #bdbfc2;
   border-radius: 0.3rem;
   padding: 0.3rem;
   font-size: 90%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  cursor: default;
+}
+
+.TimeSchedule .overlaps.scheduleHighlight {
+  margin-top: 1.5rem;
+  margin-bottom: -1.5rem;
 }
 
 .TimeSchedule .wind .scheduleHighlight {
   background-color: #d1ecf1;
-  border: 0.1rem solid #9ec5cb;
+  border-color: #9ec5cb;
 }
 
-.TimeSchedule .wind_tmp .scheduleHighlight, .TimeSchedule .wind .striped.scheduleHighlight {
+.TimeSchedule .wind_temp .scheduleHighlight, .TimeSchedule .wind .striped.scheduleHighlight {
   background: repeating-linear-gradient(
     45deg,
     #d1ecf1,
@@ -74,10 +95,10 @@ div.TimeSchedule > div.col > div.row > div.col{
     #bee5eb 0.6rem,
     #bee5eb 1.2rem
   );
-  border: 0.1rem solid #9ec5cb;
+  border-color: #9ec5cb;
 }
 
-.TimeSchedule .wind_tmp .split.scheduleHighlight {
+.TimeSchedule .wind_temp .split.scheduleHighlight {
   background: linear-gradient(
     to bottom,
     #d1ecf1,
@@ -89,10 +110,10 @@ div.TimeSchedule > div.col > div.row > div.col{
 
 .TimeSchedule .visibility .scheduleHighlight {
   background-color: #d4edda;
-  border: 0.1rem solid #a3c6ab;
+  border-color: #a3c6ab;
 }
 
-.TimeSchedule .visibility_tmp .scheduleHighlight, .TimeSchedule .visibility .striped.scheduleHighlight{
+.TimeSchedule .visibility_temp .scheduleHighlight, .TimeSchedule .visibility .striped.scheduleHighlight{
   background: repeating-linear-gradient(
     45deg,
     #d4edda,
@@ -100,10 +121,10 @@ div.TimeSchedule > div.col > div.row > div.col{
     #c3e6cb 0.6rem,
     #c3e6cb 1.2rem
   );
-  border: 0.1rem solid #a3c6ab;
+  border-color: #a3c6ab;
 }
 
-.TimeSchedule .visibility_tmp .split.scheduleHighlight {
+.TimeSchedule .visibility_temp .split.scheduleHighlight {
   background: linear-gradient(
     to bottom,
     #d4edda,
@@ -115,10 +136,10 @@ div.TimeSchedule > div.col > div.row > div.col{
 
 .TimeSchedule .weather .scheduleHighlight {
   background-color: #fff3cd;
-  border: 0.1rem solid #dfce9a;
+  border-color: #dfce9a;
 }
 
-.TimeSchedule .weather_tmp .scheduleHighlight, .TimeSchedule .weather .striped.scheduleHighlight {
+.TimeSchedule .weather_temp .scheduleHighlight, .TimeSchedule .weather .striped.scheduleHighlight {
   background: repeating-linear-gradient(
     45deg,
     #fff3cd,
@@ -126,10 +147,10 @@ div.TimeSchedule > div.col > div.row > div.col{
     #fbeab5 0.6rem,
     #fbeab5 1.2rem
   );
-  border: 0.1rem solid #dfce9a;
+  border-color: #dfce9a;
 }
 
-.TimeSchedule .weather_tmp .split.scheduleHighlight {
+.TimeSchedule .weather_temp .split.scheduleHighlight {
   background: linear-gradient(
     to bottom,
     #fff3cd,
@@ -141,10 +162,10 @@ div.TimeSchedule > div.col > div.row > div.col{
 
 .TimeSchedule .clouds .scheduleHighlight {
   background-color: #f8d7da;
-  border: 0.1rem solid #d5a6ab;
+  border-color: #d5a6ab;
 }
 
-.TimeSchedule .clouds_tmp .scheduleHighlight, .TimeSchedule .clouds .striped.scheduleHighlight {
+.TimeSchedule .clouds_temp .scheduleHighlight, .TimeSchedule .clouds .striped.scheduleHighlight {
   background: repeating-linear-gradient(
     45deg,
     #f8d7da,
@@ -152,10 +173,10 @@ div.TimeSchedule > div.col > div.row > div.col{
     #f5c6cb 0.6rem,
     #f5c6cb 1.2rem
   );
-  border: 0.1rem solid #d5a6ab;
+  border-color: #d5a6ab;
 }
 
-.TimeSchedule .clouds_tmp .split.scheduleHighlight {
+.TimeSchedule .clouds_temp .split.scheduleHighlight {
   background: linear-gradient(
     to bottom,
     #f8d7da,
@@ -165,9 +186,8 @@ div.TimeSchedule > div.col > div.row > div.col{
   );
 }
 
-.TimeSchedule .scheduleHighlight span {
+.TimeSchedule .scheduleHighlight div {
   display: inline-block;
-  vertical-align: middle;
 }
 
 .TimeSchedule .scheduleHighlight.rightArrow {
@@ -177,6 +197,7 @@ div.TimeSchedule > div.col > div.row > div.col{
 .TimeSchedule .scheduleHighlight.leftArrow::before {
   font-family: FontAwesome;
   font-size: 80%;
+  padding-top: 0.2rem;
   padding-right: 0.5rem;
   content: "\f053";
 }
@@ -184,6 +205,7 @@ div.TimeSchedule > div.col > div.row > div.col{
 .TimeSchedule .scheduleHighlight.rightArrow::after {
   font-family: FontAwesome;
   font-size: 80%;
+  padding-top: 0.2rem;
   padding-left: 0.5rem;
   content: "\f054";
 }
@@ -191,6 +213,7 @@ div.TimeSchedule > div.col > div.row > div.col{
 .TimeSchedule .scheduleHighlight.bothArrow::before {
   font-family: FontAwesome;
   font-size: 80%;
-  padding-left: 0.5rem;
+  padding-top: 0.2rem;
+  padding-right: 0.5rem;
   content: "\f054\f053";
 }


### PR DESCRIPTION
* When two blocks overlap in one serie, the first one (in time) will be shown normally, the second one will be shifted down a little
* The result after a 'BECMG' change, the prefix is gone and for all blocks the prefixes are shortened
* The value texts don't wrap anymore. Texts which are too long are clipped and every block has a tooltip with its content as well