### PR TITLE
Update basemaps.json

### DIFF
--- a/config/basemaps.json
+++ b/config/basemaps.json
@@ -39,11 +39,19 @@
          "tileServerType": "osm"
      }
     },
-    "OpenStreetMap_NL": {
+    "OpenStreets_NL": {
       "EPSG:3857": {
          "home": "https://s3.eu-central-1.amazonaws.com/knmi-basemaps/openstreetmapnl/",
-         "minLevel": 5,
+         "minLevel": 1,
          "maxLevel": 16,
+         "tileServerType": "osm"
+     }
+    },
+    "OpenStreetMap_NL": {
+      "EPSG:3857": {
+         "home": "https://s3.eu-central-1.amazonaws.com/knmi-basemaps/openstreetmapnl-carto/",
+         "minLevel": 1,
+         "maxLevel": 15,
          "tileServerType": "osm"
      }
     },


### PR DESCRIPTION
Modifications:

OpenStreets_NL = S3 hosted basemap: generated from OSM shapefiles and custom styling in Tilemill. Zoomlevel 1 to 16.
OpenStreetMap_NL = S3 hosted basemap: generated from OSM data with docker image (mapnik, openstreetmap-carto, generate_tiles.py), default osm mapnik style. Zoomlevel 1 to 15.