### PR TITLE
Update map_styles.js

### DIFF
--- a/src/constants/map_styles.js
+++ b/src/constants/map_styles.js
@@ -16,6 +16,14 @@ const OSM_NL_STYLE = {
   dimensions: []
 };
 
+const OPENSTREETS_NL_STYLE = {
+  name: 'OpenStreets_NL',
+  title: 'KNMI GeoWeb OpenStreets NL',
+  type: 'twms',
+  enabled: true,
+  dimensions: []
+};
+
 const ESRI_ARCGIS_CANVAS = {
   name: 'arcGisCanvas',
   title: 'ESRI ArcGIS canvas map',


### PR DESCRIPTION
Modifications:

OPENSTREETS_NL_STYLE = OpenStreets_NL = S3 hosted basemap: generated from OSM shapefiles and custom styling in Tilemill. Zoomlevel 1 to 16.
OSM_NL_STYLE= OpenStreetMap_NL = S3 hosted basemap: generated from OSM data with docker image (mapnik, openstreetmap-carto, generate_tiles.py), default osm mapnik style. Zoomlevel 1 to 15.