### PR TITLE
fix(SIGMET): level values are displayed with leading zeros

### DIFF
--- a/src/components/Sigmet/SigmetReadMode.jsx
+++ b/src/components/Sigmet/SigmetReadMode.jsx
@@ -24,8 +24,8 @@ class SigmetReadMode extends PureComponent {
   };
 
   getValueLabel (value, unit) {
-    if (typeof value !== 'number') {
-      return value;
+    if (typeof value !== 'number' || value === 0) {
+      return null;
     }
     const valueAsString = value.toString();
     let minimalCharactersCount = 0;
@@ -57,20 +57,34 @@ class SigmetReadMode extends PureComponent {
     const unit1Label = this.getUnitLabel(level1.unit);
     switch (levelinfo.mode) {
       case MODES_LVL.ABV:
-        return `Above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
+        return unit0Label && value0Label
+          ? `Above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`
+          : null;
       case MODES_LVL.AT:
-        return `At ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
+        return unit0Label && value0Label
+          ? `At ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`
+          : null;
       case MODES_LVL.BETW:
-        return `Between ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''} and
-          ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`;
+        return unit0Label && value0Label && unit1Label && value1Label
+          ? `Between ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''} and
+            ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`
+          : null;
       case MODES_LVL.BETW_SFC:
-        return `Between surface and ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`;
+        return unit1Label && value1Label
+          ? `Between surface and ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`
+          : null;
       case MODES_LVL.TOPS:
-        return `Tops at ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
+        return unit0Label && value0Label
+          ? `Tops at ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`
+          : null;
       case MODES_LVL.TOPS_ABV:
-        return `Tops above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
+        return unit0Label && value0Label
+          ? `Tops above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`
+          : null;
       case MODES_LVL.TOPS_BLW:
-        return `Tops below ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
+        return unit0Label && value0Label
+          ? `Tops below ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`
+          : null;
       default:
         return '';
     }

--- a/src/components/Sigmet/SigmetReadMode.jsx
+++ b/src/components/Sigmet/SigmetReadMode.jsx
@@ -23,6 +23,26 @@ class SigmetReadMode extends PureComponent {
     return UNITS_ALT.find((unit) => unit.unit === unitName).label;
   };
 
+  getValueLabel (value, unit) {
+    if (typeof value !== 'number') {
+      return value;
+    }
+    const valueAsString = value.toString();
+    let minimalCharactersCount = 0;
+    switch (unit) {
+      case UNITS.FL:
+        minimalCharactersCount = 3;
+        break;
+      case UNITS.M:
+      case UNITS.FT:
+        minimalCharactersCount = 4;
+        break;
+      default:
+        break;
+    }
+    return valueAsString.padStart(minimalCharactersCount, '0');
+  };
+
   showLevels (levelinfo) {
     if (!levelinfo) {
       return;
@@ -31,24 +51,26 @@ class SigmetReadMode extends PureComponent {
     const level1 = levelinfo.levels[1];
     const is0FL = level0.unit === UNITS.FL;
     const is1FL = level1.unit === UNITS.FL;
+    const value0Label = this.getValueLabel(level0.value, level0.unit);
     const unit0Label = this.getUnitLabel(level0.unit);
+    const value1Label = this.getValueLabel(level1.value, level1.unit);
     const unit1Label = this.getUnitLabel(level1.unit);
     switch (levelinfo.mode) {
       case MODES_LVL.ABV:
-        return `Above ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''}`;
+        return `Above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
       case MODES_LVL.AT:
-        return `At ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''}`;
+        return `At ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
       case MODES_LVL.BETW:
-        return `Between ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''} and
-          ${is1FL ? unit1Label : ''} ${level1.value} ${!is1FL ? unit1Label : ''}`;
+        return `Between ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''} and
+          ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`;
       case MODES_LVL.BETW_SFC:
-        return `Between surface and ${is1FL ? unit1Label : ''} ${level1.value} ${!is1FL ? unit1Label : ''}`;
+        return `Between surface and ${is1FL ? unit1Label : ''} ${value1Label} ${!is1FL ? unit1Label : ''}`;
       case MODES_LVL.TOPS:
-        return `Tops at ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''}`;
+        return `Tops at ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
       case MODES_LVL.TOPS_ABV:
-        return `Tops above ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''}`;
+        return `Tops above ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
       case MODES_LVL.TOPS_BLW:
-        return `Tops below ${is0FL ? unit0Label : ''} ${level0.value} ${!is0FL ? unit0Label : ''}`;
+        return `Tops below ${is0FL ? unit0Label : ''} ${value0Label} ${!is0FL ? unit0Label : ''}`;
       default:
         return '';
     }

--- a/src/styles/sigmet.scss
+++ b/src/styles/sigmet.scss
@@ -139,6 +139,17 @@
       margin-right: 0.2rem;
     }
 
+    .Switch > .col-auto {
+      flex-basis: 0;
+      flex-grow: 1;
+      > label {
+        flex: 1;
+        > .checkbox + span {
+          flex: 1;
+        }
+      }
+    }
+
     .btn-group {
       height: 100%;
 
@@ -200,7 +211,7 @@
             margin-top: 0.8rem;
           }
           > span:first-of-type {
-            margin-left: 0.65rem;
+            margin-left: 0.75rem;
           }
           > span .label.input-group {
             margin: 0;

--- a/src/styles/sigmet.scss
+++ b/src/styles/sigmet.scss
@@ -283,8 +283,9 @@
   .row.disabled .row {
     border-top: unset;
   }
-  .disabled .form-control:disabled, .disabled .btn-secondary:disabled {
+  .disabled .form-control:disabled, .form-control:disabled, button.dropdown-toggle:disabled {
     background: #f4f4f4;
+    cursor: not-allowed;
   }
   .row.disabled ~ .disabled {
     border-radius: unset;
@@ -297,8 +298,9 @@
     font-family: inherit;
     color: #666;
   }
-  .disabled label, .disabled span:not(.fa):not(.badge), .disabled input::placeholder, .disabled button.dropdown-toggle {
+  .disabled label, .disabled span:not(.fa):not(.badge), .disabled input::placeholder, .form-control:disabled::placeholder, button.dropdown-toggle:disabled {
     color: #999;
+    cursor: not-allowed;
   }
 
   .badge {


### PR DESCRIPTION
The display and range of the level values has been changed:

- introduced leading zeros, specific for FL, ft and m
- set the valid range accordingly (for scroll wheel input and validation marking)