### PR TITLE
GW-85: TAF Validation - VV000 should be possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoweb-frontend",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "GeoWeb FrontEnd is the platform for the Early Warning Center and Weather Room",
   "main": "index.js",
   "engines": {

--- a/src/components/Taf/TafFieldsConverter.js
+++ b/src/components/Taf/TafFieldsConverter.js
@@ -354,7 +354,7 @@ const jsonToTacForClouds = (cloudsAsJson, useFallback = false) => {
 
 const jsonToTacForVerticalVisibility = (verticalVisibilityAsJson, useFallback = false) => {
   let result = null;
-  if (verticalVisibilityAsJson && typeof verticalVisibilityAsJson === 'number') {
+  if (verticalVisibilityAsJson !== null && typeof verticalVisibilityAsJson === 'number') {
     result = 'VV' + verticalVisibilityAsJson.toString().padStart(3, '0');
   } else if (useFallback && verticalVisibilityAsJson && verticalVisibilityAsJson.hasOwnProperty('fallback')) {
     result = verticalVisibilityAsJson.fallback.value;


### PR DESCRIPTION
This development solves a bug related to VV000 TAF validation.
After the changes, it is possible to insert VV000, in the TAF CLOUD field, and it remains displayed in the form. VV000 is changed in the timeboard to another cloudbase when you change it.